### PR TITLE
SABnzbd ingress

### DIFF
--- a/sabnzbd/Dockerfile
+++ b/sabnzbd/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/linuxserver/sabnzbd:latest
 RUN apt-get -qq update \
-    && apt-get -qq install --no-install-recommends -y jq \
+    && apt-get -qq install --no-install-recommends -y jq nginx \
     && (apt-get autoremove -y; apt-get autoclean -y) \
     && curl -J -L -o /tmp/bashio.tar.gz "https://github.com/hassio-addons/bashio/archive/v0.14.3.tar.gz" \
     && mkdir /tmp/bashio \
@@ -9,5 +9,5 @@ RUN apt-get -qq update \
     && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
     && curl -L -s -o /usr/bin/tempio "https://github.com/home-assistant/tempio/releases/download/2021.09.0/tempio_$(uname -m)" \
     && chmod a+x /usr/bin/tempio \
-    && rm -rf /tmp/*
+    && rm -rf /tmp/* /etc/nginx
 COPY rootfs /

--- a/sabnzbd/Dockerfile
+++ b/sabnzbd/Dockerfile
@@ -1,2 +1,13 @@
 FROM ghcr.io/linuxserver/sabnzbd:latest
+RUN apt-get -qq update \
+    && apt-get -qq install --no-install-recommends -y jq \
+    && (apt-get autoremove -y; apt-get autoclean -y) \
+    && curl -J -L -o /tmp/bashio.tar.gz "https://github.com/hassio-addons/bashio/archive/v0.14.3.tar.gz" \
+    && mkdir /tmp/bashio \
+    && tar zxvf /tmp/bashio.tar.gz --strip 1 -C /tmp/bashio \
+    && mv /tmp/bashio/lib /usr/lib/bashio \
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
+    && curl -L -s -o /usr/bin/tempio "https://github.com/home-assistant/tempio/releases/download/2021.09.0/tempio_$(uname -m)" \
+    && chmod a+x /usr/bin/tempio \
+    && rm -rf /tmp/*
 COPY rootfs /

--- a/sabnzbd/config.json
+++ b/sabnzbd/config.json
@@ -1,6 +1,6 @@
 {
   "name": "SABnzbd",
-  "version": "3.4.2-ls50",
+  "version": "3.4.2-ingress",
   "slug": "sabnzbd",
   "description": "SABnzbd is an Open Source Binary Newsreader written in Python.",
   "url": "https://github.com/evilmarty/hassio-addons/tree/master/sabnzbd",

--- a/sabnzbd/config.json
+++ b/sabnzbd/config.json
@@ -10,20 +10,10 @@
     "aarch64",
     "armhf"
   ],
-  "startup": "application",
-  "init": false,
-  "boot": "auto",
-  "services": [],
-  "webui": "http://[HOST]:[PORT:8080]",
-  "panel_icon": "mdi:selection-ellipse",
-  "ports": {
-    "8080/tcp": 8080,
-    "9090/tcp": null
-  },
-  "ports_description": {
-    "8080/tcp": "HTTP port for the WebUI",
-    "9090/tcp": "HTTPS port for the WebUI"
-  },
+  "startup": "services",
+  "panel_icon": "mdi:download-multiple",
+  "ingress": true,
+  "ingress_stream": true,
   "map": [
     "share:rw",
     "ssl:ro",

--- a/sabnzbd/rootfs/etc/cont-init.d/20-config
+++ b/sabnzbd/rootfs/etc/cont-init.d/20-config
@@ -4,6 +4,9 @@
 # ==============================================================================
 readonly CONFIG=/data/sabnzbd.ini
 readonly OLD_CONFIG=/data/config/sabnzbd.ini
+declare ingress_entry
+
+ingress_entry=$(bashio::addon.ingress_entry)
 
 if [ -f "$OLD_CONFIG" ]; then
   bashio::log.warning "Config found in deprecated location. Moving..."
@@ -21,8 +24,13 @@ if [ ! -f "$CONFIG" ]; then
   mkdir -p /share/downloads /share/incomplete-downloads
   cat <<CONFIG > "$CONFIG"
 [misc]
+url_base = $ingress_entry
 download_dir = /share/incomplete-downloads
 complete_dir = /share/downloads
 check_new_rel = 0
 CONFIG
+else
+  bashio::log.notice "Updating config with ingress entry..."
+  sed -i -e '/^url_base/d' -e "/\[misc\]/a\url_base = ${ingress_entry}/" "$CONFIG"
 fi
+

--- a/sabnzbd/rootfs/etc/cont-init.d/20-config
+++ b/sabnzbd/rootfs/etc/cont-init.d/20-config
@@ -1,14 +1,28 @@
-#!/usr/bin/with-contenv bash
+#!/usr/bin/with-contenv bashio
 # ==============================================================================
 # Init folder & structures
 # ==============================================================================
-mkdir -p /data/config /share/downloads /share/incomplete-downloads
+readonly CONFIG=/data/sabnzbd.ini
+readonly OLD_CONFIG=/data/config/sabnzbd.ini
 
-if [ ! -f /data/config/sabnzbd.ini ];
-then
-  cat <<CONFIG > /data/config/sabnzbd.ini
+if [ -f "$OLD_CONFIG" ]; then
+  bashio::log.warning "Config found in deprecated location. Moving..."
+  (
+    cd $(dirname $OLD_CONFIG)
+    find . -type d -exec mkdir -p ../{} \;
+    find . -type f -exec cp {} ../{} \;
+  )
+  bashio::log.warning "Removing deprecated config location..."
+  rm -rf $(dirname $OLD_CONFIG)
+fi
+
+if [ ! -f "$CONFIG" ]; then
+  bashio::log.info "Bootstrapping SABnzbd folders and config..."
+  mkdir -p /share/downloads /share/incomplete-downloads
+  cat <<CONFIG > "$CONFIG"
 [misc]
 download_dir = /share/incomplete-downloads
 complete_dir = /share/downloads
+check_new_rel = 0
 CONFIG
 fi

--- a/sabnzbd/rootfs/etc/nginx/includes/mime.types
+++ b/sabnzbd/rootfs/etc/nginx/includes/mime.types
@@ -1,0 +1,96 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+}

--- a/sabnzbd/rootfs/etc/nginx/includes/proxy_params.conf
+++ b/sabnzbd/rootfs/etc/nginx/includes/proxy_params.conf
@@ -1,0 +1,15 @@
+proxy_http_version          1.1;
+proxy_ignore_client_abort   off;
+proxy_read_timeout          86400s;
+proxy_redirect              off;
+proxy_send_timeout          86400s;
+proxy_max_temp_file_size    0;
+
+proxy_set_header Accept-Encoding "";
+proxy_set_header Connection "";
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-NginX-Proxy true;
+proxy_set_header X-Real-IP $remote_addr;

--- a/sabnzbd/rootfs/etc/nginx/includes/server_params.conf
+++ b/sabnzbd/rootfs/etc/nginx/includes/server_params.conf
@@ -1,0 +1,6 @@
+root            /dev/null;
+server_name     $hostname;
+
+add_header X-Content-Type-Options nosniff;
+add_header X-XSS-Protection "1; mode=block";
+add_header X-Robots-Tag none;

--- a/sabnzbd/rootfs/etc/nginx/includes/ssl_params.conf
+++ b/sabnzbd/rootfs/etc/nginx/includes/ssl_params.conf
@@ -1,0 +1,8 @@
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_prefer_server_ciphers off;
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+ssl_session_timeout  10m;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+ssl_stapling on;
+ssl_stapling_verify on;

--- a/sabnzbd/rootfs/etc/nginx/includes/upstream.conf
+++ b/sabnzbd/rootfs/etc/nginx/includes/upstream.conf
@@ -1,0 +1,3 @@
+upstream backend {
+    server 127.0.0.1:8080 max_fails=0;
+}

--- a/sabnzbd/rootfs/etc/nginx/nginx.conf
+++ b/sabnzbd/rootfs/etc/nginx/nginx.conf
@@ -1,0 +1,44 @@
+# Run nginx in foreground.
+daemon off;
+
+# This is run inside Docker.
+user root;
+
+# Pid storage location.
+pid /var/run/nginx.pid;
+
+# Set number of worker processes.
+worker_processes 1;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Write error log to the add-on log.
+error_log /proc/1/fd/1 error;
+
+# Max num of simultaneous connections by a worker process.
+events {
+    worker_connections 512;
+}
+
+http {
+    include /etc/nginx/includes/mime.types;
+
+    access_log              off;
+    client_max_body_size    4G;
+    default_type            application/octet-stream;
+    gzip                    on;
+    keepalive_timeout       65;
+    sendfile                on;
+    server_tokens           off;
+    tcp_nodelay             on;
+    tcp_nopush              on;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    include /etc/nginx/includes/upstream.conf;
+    include /etc/nginx/servers/*.conf;
+}

--- a/sabnzbd/rootfs/etc/nginx/servers/ingress.conf
+++ b/sabnzbd/rootfs/etc/nginx/servers/ingress.conf
@@ -1,0 +1,21 @@
+server {
+    listen 8099 default_server;
+
+    include /etc/nginx/includes/server_params.conf;
+    include /etc/nginx/includes/proxy_params.conf;
+
+    location / {
+        allow   172.30.32.2;
+        deny    all;
+
+        proxy_pass http://backend/;
+
+        # Nasty hack because SABnzbd strips the trailing slash
+        # and doesn't affix a new one when redirecting to root.
+        # This is an issue as the hassio ingress controller doesn't
+        # handle slash-less paths.
+        sub_filter '$http_x_ingress_path"' '$http_x_ingress_path/"';
+        sub_filter "$http_x_ingress_path'" "$http_x_ingress_path/'";
+        sub_filter_once off;
+    }
+}

--- a/sabnzbd/rootfs/etc/services.d/nginx/finish
+++ b/sabnzbd/rootfs/etc/services.d/nginx/finish
@@ -1,0 +1,8 @@
+#!/usr/bin/execlineb -S0
+# ==============================================================================
+# Take down the S6 supervision tree when Nginx fails
+# ==============================================================================
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/sabnzbd/rootfs/etc/services.d/nginx/run
+++ b/sabnzbd/rootfs/etc/services.d/nginx/run
@@ -1,0 +1,11 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Home Assistant Community Add-on: SABnzbd
+# Runs the Nginx daemon
+# ==============================================================================
+
+# Wait for SABnzbd to become available
+bashio::net.wait_for 8080 localhost 300
+
+bashio::log.info "Starting NGinX..."
+exec nginx

--- a/sabnzbd/rootfs/etc/services.d/sabnzbd/finish
+++ b/sabnzbd/rootfs/etc/services.d/sabnzbd/finish
@@ -1,0 +1,8 @@
+#!/usr/bin/execlineb -S0
+# ==============================================================================
+# Take down the S6 supervision tree when SABnzbd fails
+# ==============================================================================
+if { s6-test ${1} -ne 0 }
+if { s6-test ${1} -ne 256 }
+
+s6-svscanctl -t /var/run/s6/services

--- a/sabnzbd/rootfs/etc/services.d/sabnzbd/run
+++ b/sabnzbd/rootfs/etc/services.d/sabnzbd/run
@@ -2,4 +2,4 @@
 
 exec \
   s6-setuidgid abc python3 /app/sabnzbd/SABnzbd.py \
-  --config-file /data/config --server 0.0.0.0:8080 --browser 0
+  --config-file /data/config --server 0.0.0.0:8080 --browser 0 --disable-file-log --console

--- a/sabnzbd/rootfs/etc/services.d/sabnzbd/run
+++ b/sabnzbd/rootfs/etc/services.d/sabnzbd/run
@@ -2,4 +2,4 @@
 
 exec \
   s6-setuidgid abc python3 /app/sabnzbd/SABnzbd.py \
-  --config-file /data/config --server 0.0.0.0:8080 --browser 0 --disable-file-log --console
+  --config-file /data --server 0.0.0.0:8080 --browser 0 --disable-file-log --console


### PR DESCRIPTION
This is a major refactor of the sabnzbd addon to use the HA supervisor ingress.

- Take down the S6 supervision tree when SABnzbd fails
- Ensure SABnzbd logs to console and not log files
- Move SABnzbd config up one directory and include bashio
- Switch SABnzbd to using ingress instead of open ports
